### PR TITLE
Feature parent access

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
-    json (2.0.2)
+    json (2.0.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)

--- a/docs/acts_as_hierarchy.md
+++ b/docs/acts_as_hierarchy.md
@@ -16,9 +16,27 @@ You can select all hierarchies accessible for specific user by using a scope: `a
 ``` ruby
 Monarchy.hierarchy_class.accessible_for(current_user)   # returns [hierarchy1, hierarchy2, hierarchy5]
 ```
+
+#### Options
 Optionally you can pass extra allowed roles which should be inherited for this request
 ``` ruby
-Monarchy.hierarchy_class.accessible_for(current_user, [:blocked, :visitors])   # returns [hierarchy1, hierarchy2, hierarchy5, hierarchy6]
+Monarchy.hierarchy_class.accessible_for(current_user, { inherited_roles: [:blocked, :visitors] })   # returns [hierarchy1, hierarchy2, hierarchy5, hierarchy6]
+```
+
+You can also determine if read (default role) access in resource should allow to access theirs children
+
+```ruby
+Monarchy.hierarchy_class.accessible_for(current_user, { parent_access: true })
+#                     (GRANTED) hierarchy1
+#                                   |
+#                                   |
+#              (GRANTED) hierarchy2   hierarchy4 (GRANTED cuz it's a parent of granted resource)
+#                            |            |
+#                            |            |
+#                            |       hierarchy5 (NOT granted - it's not a child of granted resource)
+#                            |
+#                            |
+#                        hierarchy3 (member role - GRANTED)
 ```
 
 ### .in(resource, true)

--- a/docs/acts_as_resource.md
+++ b/docs/acts_as_resource.md
@@ -69,9 +69,27 @@ You can select all resources accessible for specyfic user by using scope: `acces
 ``` ruby
 Resource.accessible_for(current_user)   # returns [resource1, resource2, resource5]
 ```
+
+#### Options
 Optionally you can pass extra allowed roles which should be inherited for this request
 ``` ruby
 Resource.accessible_for(current_user, [:blocked, :visitors])   # returns [resource1, resource2, resource5, resource6]
+```
+
+You can also determine if read (default role) access in resource should allow to access theirs children
+
+```ruby
+Resource.accessible_for(current_user, { parent_access: true })
+#                     (GRANTED) project1
+#                                  |
+#                                  |
+#              (GRANTED) project2   project4 (GRANTED cuz it's a parent of granted resource)
+#                           |          |
+#                           |          |
+#                           |       project5 (NOT granted - it's not a child of granted resource)
+#                           |
+#                           |
+#                        project3 (member role - GRANTED)
 ```
 
 ### .in(resource, true)

--- a/dummy/db/schema.rb
+++ b/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -26,40 +25,36 @@ ActiveRecord::Schema.define(version: 20160818205534) do
     t.string   "resource_type", null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.index ["parent_id"], name: "index_monarchy_hierarchies_on_parent_id"
+    t.index ["resource_id"], name: "index_monarchy_hierarchies_on_resource_id"
   end
-
-  add_index "monarchy_hierarchies", ["parent_id"], name: "index_monarchy_hierarchies_on_parent_id"
-  add_index "monarchy_hierarchies", ["resource_id"], name: "index_monarchy_hierarchies_on_resource_id"
 
   create_table "monarchy_hierarchy_hierarchies", id: false, force: :cascade do |t|
     t.integer "ancestor_id",   null: false
     t.integer "descendant_id", null: false
     t.integer "generations",   null: false
+    t.index ["ancestor_id", "descendant_id", "generations"], name: "hierarchy_anc_desc_idx", unique: true
+    t.index ["descendant_id"], name: "hierarchy_desc_idx"
   end
-
-  add_index "monarchy_hierarchy_hierarchies", ["ancestor_id", "descendant_id", "generations"], name: "hierarchy_anc_desc_idx", unique: true
-  add_index "monarchy_hierarchy_hierarchies", ["descendant_id"], name: "hierarchy_desc_idx"
 
   create_table "monarchy_members", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "hierarchy_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.index ["hierarchy_id"], name: "index_monarchy_members_on_hierarchy_id"
+    t.index ["user_id"], name: "index_monarchy_members_on_user_id"
   end
-
-  add_index "monarchy_members", ["hierarchy_id"], name: "index_monarchy_members_on_hierarchy_id"
-  add_index "monarchy_members", ["user_id"], name: "index_monarchy_members_on_user_id"
 
   create_table "monarchy_members_roles", force: :cascade do |t|
     t.integer  "role_id"
     t.integer  "member_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["member_id"], name: "index_monarchy_members_roles_on_member_id"
+    t.index ["role_id", "member_id"], name: "index_monarchy_members_roles_on_role_id_and_member_id", unique: true
+    t.index ["role_id"], name: "index_monarchy_members_roles_on_role_id"
   end
-
-  add_index "monarchy_members_roles", ["member_id"], name: "index_monarchy_members_roles_on_member_id"
-  add_index "monarchy_members_roles", ["role_id", "member_id"], name: "index_monarchy_members_roles_on_role_id_and_member_id", unique: true
-  add_index "monarchy_members_roles", ["role_id"], name: "index_monarchy_members_roles_on_role_id"
 
   create_table "monarchy_roles", force: :cascade do |t|
     t.string   "name",                              null: false
@@ -68,12 +63,11 @@ ActiveRecord::Schema.define(version: 20160818205534) do
     t.boolean  "inherited",         default: false, null: false
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
+    t.index ["inherited"], name: "index_monarchy_roles_on_inherited"
+    t.index ["inherited_role_id"], name: "index_monarchy_roles_on_inherited_role_id"
+    t.index ["level"], name: "index_monarchy_roles_on_level"
+    t.index ["name"], name: "index_monarchy_roles_on_name", unique: true
   end
-
-  add_index "monarchy_roles", ["inherited"], name: "index_monarchy_roles_on_inherited"
-  add_index "monarchy_roles", ["inherited_role_id"], name: "index_monarchy_roles_on_inherited_role_id"
-  add_index "monarchy_roles", ["level"], name: "index_monarchy_roles_on_level"
-  add_index "monarchy_roles", ["name"], name: "index_monarchy_roles_on_name", unique: true
 
   create_table "projects", force: :cascade do |t|
     t.string   "name"

--- a/lib/monarchy.rb
+++ b/lib/monarchy.rb
@@ -29,6 +29,8 @@ module Monarchy
     config.hierarchy_class_name = 'Monarchy::Hierarchy'
     config.members_access_revoke = false
     config.revoke_strategy = :revoke_member
+    config.accessible_for_options.parent_access = false
+    config.accessible_for_options.inherited_roles = []
   end
 
   not_configured do |property|

--- a/lib/monarchy/acts_as_hierarchy.rb
+++ b/lib/monarchy/acts_as_hierarchy.rb
@@ -48,8 +48,12 @@ module Monarchy
               "WHERE monarchy_members.user_id = #{user_id}) as members ON " \
                 'members.hierarchy_id = monarchy_hierarchy_hierarchies.descendant_id').select(:id)
 
-        return accessible_roots unless parent_access
-        accessible_roots.union_all(unscoped.where(parent_id: accessible_roots).select(:id))
+        parent_access ? roots_with_children(accessible_roots) : accessible_roots
+      end
+
+      def roots_with_children(accessible_roots)
+        accessible_children = unscoped.where(parent_id: accessible_roots).select(:id)
+        accessible_roots.union_all(accessible_children)
       end
 
       def accessible_leaves_ids(user_id, inherited_roles = [])

--- a/lib/monarchy/acts_as_hierarchy.rb
+++ b/lib/monarchy/acts_as_hierarchy.rb
@@ -23,25 +23,33 @@ module Monarchy
     module SupportMethods
       private
 
+      # rubocop:disable all
       def include_scopes
         scope :in, (lambda do |hierarchy, descendants = true|
           Monarchy::Validators.hierarchy(hierarchy)
           where(id: descendants ? hierarchy.descendants : hierarchy.children)
         end)
 
-        scope :accessible_for, (lambda do |user, inherited_roles = []|
+        scope :accessible_for, (lambda do |user, options = {}|
           Monarchy::Validators.user(user)
           user_id = user.id
-          where(id: accessible_roots_ids(user_id).union_all(accessible_leaves_ids(user_id, inherited_roles)))
+
+          custom_options = accessible_for_options(options)
+          where(id: accessible_roots_ids(user_id, custom_options[:parent_access])
+                      .union_all(accessible_leaves_ids(user_id, custom_options[:inherited_roles])))
         end)
       end
+      # rubocop:enable all
 
-      def accessible_roots_ids(user_id)
-        unscoped.joins('INNER JOIN monarchy_hierarchy_hierarchies ON ' \
+      def accessible_roots_ids(user_id, parent_access)
+        accessible_roots = unscoped.joins('INNER JOIN monarchy_hierarchy_hierarchies ON ' \
           'monarchy_hierarchies.id = monarchy_hierarchy_hierarchies.ancestor_id')
-                .joins('INNER JOIN (SELECT hierarchy_id FROM monarchy_members ' \
+                                   .joins('INNER JOIN (SELECT hierarchy_id FROM monarchy_members ' \
               "WHERE monarchy_members.user_id = #{user_id}) as members ON " \
                 'members.hierarchy_id = monarchy_hierarchy_hierarchies.descendant_id').select(:id)
+
+        return accessible_roots unless parent_access
+        accessible_roots.union_all(unscoped.where(parent_id: accessible_roots).select(:id))
       end
 
       def accessible_leaves_ids(user_id, inherited_roles = [])
@@ -75,6 +83,10 @@ module Monarchy
         else
           Monarchy.role_class.select(:id, :inherited).where(inherited: inherited).to_sql
         end
+      end
+
+      def accessible_for_options(options = {})
+        Monarchy.configuration.accessible_for_options.to_h.merge(options)
       end
     end
   end

--- a/lib/monarchy/acts_as_resource.rb
+++ b/lib/monarchy/acts_as_resource.rb
@@ -51,9 +51,9 @@ module Monarchy
           joins(:hierarchy).where(monarchy_hierarchies: { id: hierarchies })
         end)
 
-        scope :accessible_for, (lambda do |user, inherited_roles = []|
+        scope :accessible_for, (lambda do |user, options = {}|
           joins(:hierarchy).where(monarchy_hierarchies: { id: Monarchy.hierarchy_class
-                                                                      .accessible_for(user, inherited_roles) })
+                                                                      .accessible_for(user, options) })
         end)
       end
 

--- a/spec/models/hierarchy_spec.rb
+++ b/spec/models/hierarchy_spec.rb
@@ -164,7 +164,7 @@ describe Monarchy::Hierarchy, type: :model do
         let!(:no_access_role) { create(:role, name: :blocked, level: 1, inherited: false) }
         let!(:memo7) { create :memo, parent: memo6 }
 
-        subject { described_class.accessible_for(user, [:member]) }
+        subject { described_class.accessible_for(user, inherited_roles: [:member]) }
 
         context 'user has a member role in project' do
           before { user.grant(:member, memo3) }
@@ -188,6 +188,18 @@ describe Monarchy::Hierarchy, type: :model do
           before { user.grant(:blocked, memo3) }
           it { is_expected.to match_array([memo3.hierarchy, memo2.hierarchy, project.hierarchy]) }
         end
+      end
+    end
+
+    context 'with parent role access' do
+      let!(:member_role) { create(:role, name: :member, level: 1, inherited: false) }
+
+      before { user.grant(:member, memo5) }
+      subject { described_class.accessible_for(user, parent_access: true) }
+
+      it do
+        is_expected.to match_array([project.hierarchy, project.status.hierarchy, memo2.hierarchy,
+                                    memo1.hierarchy, memo5.hierarchy, memo3.hierarchy])
       end
     end
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -285,7 +285,7 @@ describe Resource, type: :model do
         let!(:no_access_role) { create(:role, name: :blocked, level: 1, inherited: false) }
         let!(:memo7) { create :memo, parent: memo6 }
 
-        subject { Memo.accessible_for(user, [:member]) }
+        subject { Memo.accessible_for(user, inherited_roles: [:member]) }
 
         context 'user has a member role in project' do
           before { user.grant(:member, memo3) }
@@ -305,6 +305,17 @@ describe Resource, type: :model do
           before { user.grant(:blocked, memo3) }
           it { is_expected.to match_array([memo3, memo2]) }
         end
+      end
+    end
+
+    context 'with parent role access' do
+      let!(:member_role) { create(:role, name: :member, level: 1, inherited: false) }
+
+      before { user.grant(:member, memo5) }
+      subject { Memo.accessible_for(user, parent_access: true) }
+
+      it do
+        is_expected.to match_array([memo2, memo1, memo5, memo3])
       end
     end
   end


### PR DESCRIPTION
# Assumption

Add a possibility to customize `accessible_for` with `parent_access` flag to allow user determine if children of accessible resources should be also accessible.

```ruby
Resource.accessible_for(current_user, { parent_access: true })
#                     (GRANTED) project1
#                                  |
#                                  |
#              (GRANTED) project2   project4 (GRANTED cuz it's a parent of granted resource)
#                           |          |
#                           |          |
#                           |       project5 (NOT granted - it's not a child of granted resource)
#                           |
#                           |
#                        project3 (member role - GRANTED)
```

# Todo
- [ ]  Improve parent_access query (union -> join)