### PR TITLE
Update dependencies (Gemnasium auto-update f056750aece4866407b3625441c0f03e144e680d)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,17 +52,17 @@ GEM
       tzinfo (~> 1.1)
     arel (7.1.4)
     ast (2.3.0)
-    builder (3.2.2)
+    builder (3.2.3)
     closure_tree (6.2.0)
       activerecord (>= 4.1.0)
       with_advisory_lock (>= 3.0.0)
-    codeclimate-test-reporter (1.0.4)
+    codeclimate-test-reporter (1.0.5)
       simplecov
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     configurations (2.2.2)
     database_cleaner (1.5.3)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
     erubis (2.7.0)
     factory_girl (4.8.0)
@@ -146,8 +146,8 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.46.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -155,7 +155,7 @@ GEM
     ruby-progressbar (1.8.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.12.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -174,8 +174,8 @@ GEM
     tqdm (0.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.2)
-    websocket-driver (0.6.4)
+    unicode-display_width (1.1.3)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     with_advisory_lock (3.0.0)
@@ -187,7 +187,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.12)
-  codeclimate-test-reporter (= 1.0.4)
+  codeclimate-test-reporter (~> 1.0.5)
   database_cleaner (= 1.5.3)
   factory_girl_rails (= 4.8.0)
   ffaker (= 2.4.0)
@@ -197,14 +197,13 @@ DEPENDENCIES
   rake (~> 12.0)
   rspec (= 3.5.0)
   rspec-rails (= 3.5.2)
-  rubocop (= 0.46.0)
+  rubocop (= 0.47.1)
   shoulda-matchers (= 3.1.1)
-  simplecov (= 0.12.0)
+  simplecov (= 0.13.0)
   sqlite3 (= 1.3.13)
-  tqdm (= 0.3.0)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.14.3


### PR DESCRIPTION
Update dependencies:
simplecov: 0.12.0 => 0.13.0
builder: 3.2.2 => 3.2.3
diff-lcs: 1.2.5 => 1.3
unicode-display_width: 1.1.2 => 1.1.3
rubocop: 0.46.0 => 0.47.1
websocket-driver: 0.6.4 => 0.6.5
codeclimate-test-reporter: 1.0.4 => 1.0.5